### PR TITLE
Affichage des produits receptionnés triés par ordre alphabétique

### DIFF
--- a/src/screens/GoodsReceipt/Show.tsx
+++ b/src/screens/GoodsReceipt/Show.tsx
@@ -87,6 +87,18 @@ export default class GoodsReceiptShow extends React.Component<GoodsReceiptShowPr
                 if (!session) {
                     throw new Error('Session not found');
                 }
+                if (session.goodsReceiptEntries && session.goodsReceiptEntries.length > 0) {
+                    session.goodsReceiptEntries = session.goodsReceiptEntries.sort((entry1,entry2) => {
+                        if (entry1.productName && entry2.productName && entry1.productName.trim() > entry2.productName.trim()) {
+                            return 1;
+                        }
+                        if (entry1.productName && entry2.productName && entry1.productName.trim() < entry2.productName.trim()) {
+                            return -1;
+                        }
+                    
+                        return 0;
+                    });
+                }
                 this.setState({
                     session,
                 });


### PR DESCRIPTION
Issue #8 : 

- Ajout d'un tri sur la liste des `GoodsReceiptEntry` du `GoodsReceiptSession` :

Je fais actuellement le reorder à la réception des données, mais on pourrait imaginer le faire au render, à vous de me dire.
Je compare également le trim des valeurs, car je suis tombé sur des `productName` avec espace en début et fin. 