### PR TITLE
Inventory: reload screens when modals are dismissed

### DIFF
--- a/src/screens/Inventory/List.tsx
+++ b/src/screens/Inventory/List.tsx
@@ -40,6 +40,8 @@ export default class InventoryList extends React.Component<InventoryListProps, I
         },
     };
 
+    modalDismissedListener?: EmitterSubscription;
+
     constructor(props: InventoryListProps) {
         super(props);
         Navigation.events().bindComponent(this);
@@ -65,7 +67,17 @@ export default class InventoryList extends React.Component<InventoryListProps, I
     }
 
     componentDidMount(): void {
-        // this.loadData();
+        this.modalDismissedListener = Navigation.events().registerModalDismissedListener(() => {
+            this.loadData();
+        });
+
+        this.loadData();
+    }
+
+    componentWillUnmount(): void {
+        if (this.modalDismissedListener) {
+            this.modalDismissedListener.remove();
+        }
     }
 
     loadData(): void {

--- a/src/screens/Inventory/Show.tsx
+++ b/src/screens/Inventory/Show.tsx
@@ -31,6 +31,8 @@ interface InventoryData {
 }
 
 export default class InventoryShow extends React.Component<InventoryShowProps, InventoryShowState> {
+    modalDismissedListener?: EmitterSubscription;
+
     constructor(props: InventoryShowProps) {
         super(props);
         Navigation.events().bindComponent(this);
@@ -45,6 +47,20 @@ export default class InventoryShow extends React.Component<InventoryShowProps, I
         const options = defaultScreenOptions('Inventaire');
 
         return options;
+    }
+
+    componentDidMount(): void {
+        this.modalDismissedListener = Navigation.events().registerModalDismissedListener(() => {
+            this.loadInventorySession();
+        });
+
+        this.loadInventorySession();
+    }
+
+    componentWillUnmount(): void {
+        if (this.modalDismissedListener) {
+            this.modalDismissedListener.remove();
+        }
     }
 
     componentDidAppear(): void {


### PR DESCRIPTION
Fixes #55 

A tester:
- lors de l'ajout d'un nouvel inventaire, la liste doit se mettre à jour toute seule
- lors du scan de produits lors d'un inventaire, à la fermeture du scanner, la liste doit se mettre à jour toute seule