### PR TITLE
Blocage orientation sur Android

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,6 +27,11 @@ Database.connect();
 EStyleSheet.build({});
 
 Navigation.events().registerAppLaunchedListener(() => {
+    Navigation.setDefaultOptions({
+        layout: {
+            orientation: ['portrait'],
+        },
+    });
     Navigation.setRoot({
         root: {
             component: {

--- a/src/utils/navigation.ts
+++ b/src/utils/navigation.ts
@@ -31,9 +31,6 @@ export function goHome(): void {
             selectedIconColor: 'blue',
             selectedTextColor: 'blue',
         },
-        layout: {
-            orientation: ['portrait'],
-        },
     });
 
     loadBadges();


### PR DESCRIPTION
issue #90 

Après quelques recherches et tests, j'ai utilisé cette méthode :
https://wix.github.io/react-native-navigation/docs/style-orientation

Fonctionne bien sur Android. A priori devrait également faire l'affaire pour IOs. @dehy peut-être faudrait-il vérifier que ça n'a pas d'effet de bord sur IOs, et désactiver l'autre méthode pour en avoir une seule commune ?