### PR TITLE
Infinite Scroll + Pull to Refresh

### DIFF
--- a/src/screens/GoodsReceipt/List.tsx
+++ b/src/screens/GoodsReceipt/List.tsx
@@ -25,6 +25,7 @@ interface GoodsReceiptListState {
     goodsReceiptsData: GoodsReceiptSessionsData[];
     todaysGoodsReceipts: PurchaseOrder[];
     showHidden: boolean;
+    refreshing: boolean;
 }
 
 interface GoodsReceiptSessionTapProps {
@@ -51,6 +52,7 @@ export default class GoodsReceiptList extends React.Component<GoodsReceiptListPr
             goodsReceiptsData: [],
             todaysGoodsReceipts: [],
             showHidden: false,
+            refreshing: true,
         };
     }
 
@@ -139,9 +141,21 @@ export default class GoodsReceiptList extends React.Component<GoodsReceiptListPr
                 //console.log(goodsReceiptSessionsData);
                 this.setState({
                     goodsReceiptsData: goodsReceiptSessionsData,
+                    refreshing: false,
                 });
             });
     }
+
+    _handleRefresh = (): void => {
+        this.setState(
+            {
+                refreshing: true,
+            },
+            () => {
+                this.loadData();
+            },
+        );
+    };
 
     renderHideIcon(): void {
         const showHidden = this.state.showHidden;
@@ -334,6 +348,8 @@ export default class GoodsReceiptList extends React.Component<GoodsReceiptListPr
                         )}
                         renderItem={this.renderItem}
                         ListHeaderComponent={this.renderHeader}
+                        onRefresh={this._handleRefresh}
+                        refreshing={this.state.refreshing}
                     />
                 </SafeAreaView>
             </ThemeProvider>

--- a/src/screens/GoodsReceipt/Show.tsx
+++ b/src/screens/GoodsReceipt/Show.tsx
@@ -301,6 +301,17 @@ export default class GoodsReceiptShow extends React.Component<GoodsReceiptShowPr
         );
     };
 
+    renderFooter = (): React.ReactElement => {
+        return (
+            <View>
+                <View>
+                    <Text style={{ fontSize: 15, margin: 5 }}>Images jointes</Text>
+                </View>
+                {this.renderImageAttachments()}
+            </View>
+        );
+    };
+
     renderEntryQty(entry: GoodsReceiptEntry): React.ReactElement {
         let correctQty;
         if (false === entry.isValidQuantity() || false === entry.isValidUom()) {
@@ -418,11 +429,7 @@ export default class GoodsReceiptShow extends React.Component<GoodsReceiptShowPr
                             />
                         )}
                         ListHeaderComponent={this.renderHeader}
-                    />
-                    <View>
-                        <Text style={{ fontSize: 15, margin: 5 }}>Images jointes</Text>
-                    </View>
-                    {this.renderImageAttachments()}
+                        ListFooterComponent={this.renderFooter}
                     />
                 </ThemeProvider>
             </SafeAreaView>

--- a/src/screens/Inventory/List.tsx
+++ b/src/screens/Inventory/List.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { EmitterSubscription, View, SafeAreaView, FlatList, ScrollView } from 'react-native';
+import { EmitterSubscription, View, SafeAreaView, FlatList } from 'react-native';
 import { defaultScreenOptions } from '../../utils/navigation';
 import { Navigation, Options } from 'react-native-navigation';
 import InventoryEntryFactory from '../../factories/InventoryEntryFactory';
@@ -14,6 +14,7 @@ export interface InventoryListProps {
 
 interface InventoryListState {
     inventoriesData: InventorySessionListItem[];
+    refreshing: boolean;
 }
 
 interface InventorySessionListItem {
@@ -47,6 +48,7 @@ export default class InventoryList extends React.Component<InventoryListProps, I
         Navigation.events().bindComponent(this);
         this.state = {
             inventoriesData: [],
+            refreshing: true,
         };
     }
 
@@ -110,11 +112,23 @@ export default class InventoryList extends React.Component<InventoryListProps, I
 
                 this.setState({
                     inventoriesData: inventoriesData,
+                    refreshing: false,
                 });
             });
     }
 
-    openNewInventoryModal(): void {
+    _handleRefresh = (): void => {
+        this.setState(
+            {
+                refreshing: true,
+            },
+            () => {
+                this.loadData();
+            },
+        );
+    };
+
+    openNewInventoryModal = (): void => {
         Navigation.showModal({
             stack: {
                 children: [
@@ -126,10 +140,9 @@ export default class InventoryList extends React.Component<InventoryListProps, I
                 ],
             },
         });
-    }
+    };
 
     navigationButtonPressed({ buttonId }: { buttonId: string }): void {
-        // will be called when "buttonOne" is clicked
         if (buttonId === 'inventory-new') {
             this.openNewInventoryModal();
         }
@@ -146,17 +159,19 @@ export default class InventoryList extends React.Component<InventoryListProps, I
         });
     };
 
-    renderHeader(): React.ReactElement {
+    renderHeader = (): React.ReactElement => {
         return (
             <View style={{ padding: 8, flexDirection: 'row', justifyContent: 'center' }}>
                 <Button
                     title=" Nouvel inventaire"
                     icon={<Icon name="plus-circle" color="white" />}
-                    onPress={this.openNewInventoryModal}
+                    onPress={(): void => {
+                        this.openNewInventoryModal();
+                    }}
                 />
             </View>
         );
-    }
+    };
 
     render(): React.ReactNode {
         return (
@@ -182,6 +197,8 @@ export default class InventoryList extends React.Component<InventoryListProps, I
                             />
                         )}
                         ListHeaderComponent={this.renderHeader}
+                        onRefresh={this._handleRefresh}
+                        refreshing={this.state.refreshing}
                     />
                 </SafeAreaView>
             </ThemeProvider>

--- a/src/screens/News/List.tsx
+++ b/src/screens/News/List.tsx
@@ -13,6 +13,7 @@ export interface NewsListProps {
 
 interface NewsListState {
     news: NewsItem[];
+    refreshing: boolean;
 }
 
 export default class NewsList extends React.Component<NewsListProps, NewsListState> {
@@ -21,6 +22,7 @@ export default class NewsList extends React.Component<NewsListProps, NewsListSta
         Navigation.events().bindComponent(this);
         this.state = {
             news: [],
+            refreshing: true,
         };
     }
 
@@ -45,9 +47,21 @@ export default class NewsList extends React.Component<NewsListProps, NewsListSta
                 }
                 this.setState({
                     news: allTheNews,
+                    refreshing: false,
                 });
             });
     }
+
+    _handleRefresh = (): void => {
+        this.setState(
+            {
+                refreshing: true,
+            },
+            () => {
+                this.loadData();
+            },
+        );
+    };
 
     static get options(): Options {
         return defaultScreenOptions('Actualités');
@@ -81,6 +95,8 @@ export default class NewsList extends React.Component<NewsListProps, NewsListSta
                             chevron
                         />
                     )}
+                    onRefresh={this._handleRefresh}
+                    refreshing={this.state.refreshing}
                 />
             </SafeAreaView>
         );

--- a/src/utils/Odoo.ts
+++ b/src/utils/Odoo.ts
@@ -156,23 +156,14 @@ export default class Odoo {
         return [];
     }
 
-    async fetchWaitingPurchaseOrders(): Promise<PurchaseOrder[]> {
+    async fetchWaitingPurchaseOrders(page = 1): Promise<PurchaseOrder[]> {
         await this.assertConnect();
 
         const params = {
-            domain: [
-                ['state', '=', 'purchase'],
-                [
-                    'date_planned',
-                    '>',
-                    moment()
-                        .subtract(2, 'week')
-                        .format(Dates.ODOO_DATETIME_FORMAT),
-                ],
-            ],
+            domain: [['state', '=', 'purchase']],
             fields: ['id', 'name', 'partner_id', 'date_order', 'date_planned'],
-            //limit: 10,
-            offset: 0,
+            limit: 20,
+            offset: 20 * (page - 1),
             order: 'date_planned DESC',
         };
 


### PR DESCRIPTION
closes #99 

On peut maintenant pull to Refrsh sur les News, la liste des inventaires, la liste des réceptions et les nouvelles réceptions.
Lors des nouvelles réception, une fois arrivé en bas de liste, la suite est chargée à la volée.